### PR TITLE
Basic header based auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'bcrypt', '~> 3.1.7'
 # Use Unicorn as the app server
 # gem 'unicorn'
 
+#
+gem 'jwt'
 
 # Handle CORS requests from JHO client applications
 gem 'rack-cors', :require => 'rack/cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     json_spec (1.1.4)
       multi_json (~> 1.0)
       rspec (>= 2.0, < 4.0)
+    jwt (1.4.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -205,6 +206,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   json_spec
+  jwt
   pg
   puma
   rack-cors

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,10 +15,7 @@ class ApplicationController < ActionController::API
   def signed_in?
     received_token = request.env["HTTP_AUTH_TOKEN"] #=> returns the token
     #request.env["HTTP_NAME"] #=> returns the name
-    request.headers["name"] #=> returns the name
-    #p request.headers["auth_token"] #=> returns nil
-    @user = User.find_by(name: request.headers["name"])
-    @user.auth_token
+    @user = User.find_by(name: request.env["HTTP_NAME"])
     if @user && @user.auth_token == received_token
       true
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,12 +13,30 @@ class ApplicationController < ActionController::API
   helper_method :current_user
 
   def signed_in?
+    received_token = request.env["HTTP_AUTH_TOKEN"] #=> returns the token
+    #request.env["HTTP_NAME"] #=> returns the name
+    request.headers["name"] #=> returns the name
+    #p request.headers["auth_token"] #=> returns nil
     @user = User.find_by(name: request.headers["name"])
-    if @user && @user.auth_token == request.headers["auth_token"]
+    @user.auth_token
+    if @user && @user.auth_token == received_token
       true
     else
       render nothing: true, status: 401
     end
   end
   helper_method :signed_in?
+
+  # def authenticate
+  #   decode_token
+  #   verify_token
+  # end
+
+  # def verify_token
+  #   # https://github.com/jwt/ruby-jwt
+  # end
+
+  # def decode_token
+  #   # https://github.com/jwt/ruby-jwt
+  # end
 end

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -2,7 +2,7 @@ class BoardsController < ApplicationController
 
   def index
     @board = Board.new
-    @user = User.where(auth_token: request.headers["auth_token"]).first
+    @user = User.where(auth_token: request.env["HTTP_AUTH_TOKEN"]).first
     @boards = Board.where(user_id: @user.id)
     render json: @boards, status: 200
   end
@@ -14,7 +14,7 @@ class BoardsController < ApplicationController
 
   def create
     @board = Board.new(board_params)
-    @user = User.where(auth_token: request.headers["auth_token"]).first
+    @user = User.where(auth_token: request.env["HTTP_AUTH_TOKEN"]).first
     @board.user_id = @user.id
     if @board.save
       render json: @board, status: 201

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
-      render json: { success: "session created, user logged in" }, status: 201, serializer: UserSerializer
+      render json: user, status: 201, serializer: UserSerializer
     else
       render nothing: true, status: 401
     end

--- a/spec/controllers/board_members_controller_spec.rb
+++ b/spec/controllers/board_members_controller_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe BoardMembersController, type: :controller do
 
     request.headers['Accept'] = "application/json"
     request.headers['Content-Type'] = "application/json"
-    request.headers['name'] = "#{@user.name}"
-    request.headers['auth_token'] = "#{@user.auth_token}"
+    request.env['HTTP_NAME'] = "#{@user.name}"
+    request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
   end
 
   describe "POST #create" do

--- a/spec/controllers/boards_controller_spec.rb
+++ b/spec/controllers/boards_controller_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe BoardsController, :type => :controller do
 
     request.headers['Accept'] = "application/json"
     request.headers['Content-Type'] = "application/json"
-    request.headers['name'] = "#{@user.name}"
-    request.headers['auth_token'] = "#{@user.auth_token}"
+    request.env['HTTP_NAME'] = "#{@user.name}"
+    request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
   end
 
   # after(:each) do

--- a/spec/controllers/card_assignments_controller_spec.rb
+++ b/spec/controllers/card_assignments_controller_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe CardAssignmentsController, type: :controller do
 
     request.headers['Accept'] = "application/json"
     request.headers['Content-Type'] = "application/json"
-    request.headers['name'] = "#{@user.name}"
-    request.headers['auth_token'] = "#{@user.auth_token}"
+    request.env['HTTP_NAME'] = "#{@user.name}"
+    request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
   end
 
   describe "POST #create" do
@@ -73,7 +73,7 @@ RSpec.describe CardAssignmentsController, type: :controller do
         it "changes card_assignment count by 0" do
           expect {
             put(:update, {id: @card_assignment.id, card_assignment: @valid_attributes})
-            }.to change{ CardAssignment.count}.by(0)
+          }.to change{ CardAssignment.count}.by(0)
         end
 
         it "renders a JSON of the created CardAssignment" do
@@ -113,7 +113,7 @@ RSpec.describe CardAssignmentsController, type: :controller do
 
           it "renders a success JSON" do
             body = JSON.parse(response.body, symbolize_names: true)
-          expect(body).to have_key(:success)
+            expect(body).to have_key(:success)
           end
 
           # it "changes Card Assignment count by -1" do

--- a/spec/controllers/cards_controller_spec.rb
+++ b/spec/controllers/cards_controller_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe CardsController, :type => :controller do
 
     request.headers['Accept'] = "application/json"
     request.headers['Content-Type'] = "application/json"
-    request.headers['name'] = "#{@user.name}"
-    request.headers['auth_token'] = "#{@user.auth_token}"
+    request.env['HTTP_NAME'] = "#{@user.name}"
+    request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
   end
 
   describe "POST #create" do

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe ListsController, type: :controller do
 
     request.headers['Accept'] = "application/json"
     request.headers['Content-Type'] = "application/json"
-    request.headers['name'] = "#{@user.name}"
-    request.headers['auth_token'] = "#{@user.auth_token}"
+    request.env['HTTP_NAME'] = "#{@user.name}"
+    request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
   end
 
   describe "POST #create" do

--- a/spec/controllers/movements_controller_spec.rb
+++ b/spec/controllers/movements_controller_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe MovementsController, type: :controller do
 
     request.headers['Accept'] = "application/json"
     request.headers['Content-Type'] = "application/json"
-    request.headers['name'] = "#{@user.name}"
-    request.headers['auth_token'] = "#{@user.auth_token}"
+    request.env['HTTP_NAME'] = "#{@user.name}"
+    request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
   end
 
   describe "POST #create" do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe SessionsController, type: :controller do
 
         request.headers['Accept'] = "application/json"
         request.headers['Content-Type'] = "application/json"
-        request.headers['name'] = "#{@user.name}"
-        request.headers['auth_token'] = "#{@user.auth_token}"
+        request.env['HTTP_NAME'] = "#{@user.name}"
+        request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
 
         post :create, session: { email: "sing@song.com" , password: "thebestyoueverhad" }
       end
@@ -19,16 +19,24 @@ RSpec.describe SessionsController, type: :controller do
         expect(response).to have_http_status 201
       end
 
-      it "renders a success JSON" do
-        body = JSON.parse(response.body, symbolize_names: true)
-        expect(body).to have_key(:success)
+      it "renders a JSON of the logged in user" do
+        body = response.body
+        user = User.last.to_json
+        expect(body).to eql user
       end
     end
 
     context "when is not created" do
       before(:each) do
+
+        @user = User.create(name: "Jigglypuff", email: "sing@song.com", password: "thebestyoueverhad", password_confirmation: "thebestyoueverhad")
+
+        request.headers['Accept'] = "application/json"
+        request.headers['Content-Type'] = "application/json"
+        request.env['HTTP_NAME'] = "#{@user.name}"
+        request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
         # same as above but user was never created
-        post :create, session: { email: "sing@song.com" , password: "thebestyoueverhad" }
+        post :create, session: { email: "sing@song.com" , password: "differentpassword" }
       end
 
       it "responds with a 401 unauthorized status" do

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe TasksController, type: :controller do
 
     request.headers['Accept'] = "application/json"
     request.headers['Content-Type'] = "application/json"
-    request.headers['name'] = "#{@user.name}"
-    request.headers['auth_token'] = "#{@user.auth_token}"
+    request.env['HTTP_NAME'] = "#{@user.name}"
+    request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
   end
 
   describe "GET #index" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe UsersController, type: :controller do
 
         request.headers['Accept'] = "application/json"
         request.headers['Content-Type'] = "application/json"
-        request.headers['name'] = "#{@user.name}"
-        request.headers['auth_token'] = "#{@user.auth_token}"
+        request.env['HTTP_NAME'] = "#{@user.name}"
+        request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
 
         @valid_attributes = { name: "Sterling Mallory Archer",
                               email: "sterling@isis.com",
@@ -92,8 +92,8 @@ RSpec.describe UsersController, type: :controller do
 
         request.headers['Accept'] = "application/json"
         request.headers['Content-Type'] = "application/json"
-        request.headers['name'] = "#{@user.name}"
-        request.headers['auth_token'] = "#{@user.auth_token}"
+        request.env['HTTP_NAME'] = "#{@user.name}"
+        request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
 
         put :update, id: @user.id, user: @invalid_attributes
       end
@@ -134,8 +134,8 @@ RSpec.describe UsersController, type: :controller do
 
         request.headers['Accept'] = "application/json"
         request.headers['Content-Type'] = "application/json"
-        request.headers['name'] = "#{@user.name}"
-        request.headers['auth_token'] = "#{@user.auth_token}"
+        request.env['HTTP_NAME'] = "#{@user.name}"
+        request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
       end
 
       it "changes the user count by -1" do
@@ -162,8 +162,8 @@ RSpec.describe UsersController, type: :controller do
 
         request.headers['Accept'] = "application/json"
         request.headers['Content-Type'] = "application/json"
-        request.headers['name'] = "#{@user.name}"
-        request.headers['auth_token'] = "#{@user.auth_token}"
+        request.env['HTTP_NAME'] = "#{@user.name}"
+        request.env['HTTP_AUTH_TOKEN'] = "#{@user.auth_token}"
 
         delete :destroy, id: "foo"
       end


### PR DESCRIPTION
Any incoming requests to the API require a name and auth_token in the header.
Planning to replace this with JWT for requests and responses, as currently the API is returning unencoded data.
